### PR TITLE
Add vote revealer (#2723)

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -458,6 +458,7 @@ static void from_json(const json& j, Config::Misc& m)
     read(j, "Reveal ranks", m.revealRanks);
     read(j, "Reveal money", m.revealMoney);
     read(j, "Reveal suspect", m.revealSuspect);
+    read(j, "Reveal votes", m.revealVotes);
     read<value_t::object>(j, "Spectator list", m.spectatorList);
     read<value_t::object>(j, "Watermark", m.watermark);
     read<value_t::object>(j, "Offscreen Enemies", m.offscreenEnemies);
@@ -834,6 +835,7 @@ static void to_json(json& j, const Config::Misc& o)
     WRITE("Reveal ranks", revealRanks);
     WRITE("Reveal money", revealMoney);
     WRITE("Reveal suspect", revealSuspect);
+    WRITE("Reveal votes", revealVotes);
     WRITE("Spectator list", spectatorList);
     WRITE("Watermark", watermark);
     WRITE("Offscreen Enemies", offscreenEnemies);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -198,6 +198,7 @@ public:
         bool revealRanks{ false };
         bool revealMoney{ false };
         bool revealSuspect{ false };
+        bool revealVotes{ false };
         bool fixAnimationLOD{ false };
         bool fixBoneMatrix{ false };
         bool fixMovement{ false };

--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -20,6 +20,7 @@ EventListener::EventListener() noexcept
     interfaces->gameEventManager->addListener(this, "bullet_impact");
 
     interfaces->gameEventManager->addListener(this, "player_death");
+    interfaces->gameEventManager->addListener(this, "vote_cast");
 
     if (const auto desc = memory->getEventDescriptor(interfaces->gameEventManager, "player_death", nullptr))
         std::swap(desc->listeners[0], desc->listeners[desc->listeners.size - 1]);
@@ -58,6 +59,9 @@ void EventListener::fireGameEvent(GameEvent* event)
         break;
     case fnv::hash("bullet_impact"):
         Visuals::bulletTracer(*event);
+        break;
+    case fnv::hash("vote_cast"):
+        Misc::voteRevealer(*event);
         break;
     }
 }

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1265,6 +1265,7 @@ void GUI::renderMiscWindow(bool contentOnly) noexcept
     ImGui::Checkbox("Reveal ranks", &config->misc.revealRanks);
     ImGui::Checkbox("Reveal money", &config->misc.revealMoney);
     ImGui::Checkbox("Reveal suspect", &config->misc.revealSuspect);
+    ImGui::Checkbox("Reveal votes", &config->misc.revealVotes);
 
     ImGui::Checkbox("Spectator list", &config->misc.spectatorList.enabled);
     ImGui::SameLine();

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -950,6 +950,23 @@ void Misc::preserveKillfeed(bool roundStart) noexcept
     }
 }
 
+void Misc::voteRevealer(GameEvent& event) noexcept
+{
+    if (!config->misc.revealVotes)
+        return;
+
+    const auto entity = interfaces->entityList->getEntity(event.getInt("entityid"));
+    if (!entity || !entity->isPlayer())
+        return;
+    
+    memory->conColorMsg({ 0, 102, 255, 255 }, "[Osiris]: ");
+    memory->debugMsg("%s : ", entity->getPlayerName().c_str());
+    if (event.getInt("vote_option") == 0)
+        memory->conColorMsg({ 0, 255, 0, 255 }, "Yes\n");
+    else
+        memory->conColorMsg({ 255, 0, 0, 255 }, "No\n");
+}
+
 void Misc::drawOffscreenEnemies(ImDrawList* drawList) noexcept
 {
     if (!config->misc.offscreenEnemies.enabled)

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -46,6 +46,7 @@ namespace Misc
     void runReportbot() noexcept;
     void resetReportbot() noexcept;
     void preserveKillfeed(bool roundStart = false) noexcept;
+    void voteRevealer(GameEvent& event) noexcept;
     void drawOffscreenEnemies(ImDrawList* drawList) noexcept;
     void autoAccept(const char* soundEntry) noexcept;
 


### PR DESCRIPTION
* add vote revealer

* Update Misc.cpp

* forgot this

* Remove code that does nothing

* Change Misc::voteRevealer() argument type from GameEvent* to GameEvent&

* Make sure entity is player in Misc::voteRevealer()

* Make Misc::voteRevealer() function noexcept

Co-authored-by: Daniel Krupiński <danielkrupinski@outlook.com>